### PR TITLE
Fix race condition during dispose

### DIFF
--- a/Rnwood.SmtpServer/Rnwood.SmtpServer.xml
+++ b/Rnwood.SmtpServer/Rnwood.SmtpServer.xml
@@ -2755,6 +2755,7 @@
             <summary>
             Gets the ActiveConnections.
             </summary>
+            <remarks>Note: this is not thread-safe for enumeration.</remarks>
         </member>
         <member name="P:Rnwood.SmtpServer.SmtpServer.Behaviour">
             <summary>


### PR DESCRIPTION
During dispose, an exception can be thrown:
`System.InvalidOperationException : Collection was modified; enumeration operation may not execute`.

This is because while `activeConnections` is a synchronized list, it's not thread-safe for enumeration. The [docs](https://docs.microsoft.com/en-us/dotnet/api/system.collections.arraylist.synchronized?view=net-5.0) recommend a lock on the SyncRoot property before enumeration.

I was also tempted to make `ActiveConnections` internal and/or remove it in preference of checking the `count` method (which uses the lock), but wasn't sure how much of a breaking change that might be, so I left it for now. I added a comment to the xmldoc comments to salve my conscience 😄 

I couldn't come up with a nice test here, unfortunately.

Fixes https://github.com/rnwood/smtpserver/issues/125