### PR TITLE
AcceptTcpClientAsync can also throw SocketException

### DIFF
--- a/Rnwood.SmtpServer/SmtpServer.cs
+++ b/Rnwood.SmtpServer/SmtpServer.cs
@@ -253,6 +253,17 @@ namespace Rnwood.SmtpServer
 			{
 				tcpClient = await this.listener.AcceptTcpClientAsync().ConfigureAwait(false);
 			}
+			catch (SocketException)
+			{
+				if (this.IsRunning)
+				{
+					throw;
+				}
+
+				this.logger.LogDebug("Got SocketException on listener, shutting down");
+
+				// normal - caused by _listener.Stop();
+			}
 			catch (InvalidOperationException)
 			{
 				if (this.IsRunning)


### PR DESCRIPTION
It seems the call to `AcceptTcpClientAsync ` in https://github.com/rnwood/smtpserver/blob/56702c5664f81868cc48347f99f5ca48992d8c13/Rnwood.SmtpServer/SmtpServer.cs#L254 can also throw `SocketException`, as documented in https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.tcplistener.accepttcpclientasync?view=net-5.0#exceptions

Interesting enough I am getting the following stacktrace on disposing of `SmtpServer` instances randomly!
```
System.AggregateException : One or more errors occurred. (One or more errors occurred. (The I/O operation has been aborted because of either a thread exit or an application request.))
  ----> System.AggregateException : One or more errors occurred. (The I/O operation has been aborted because of either a thread exit or an application request.)
  ----> System.Net.Sockets.SocketException : The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at Rnwood.SmtpServer.SmtpServer.Stop(Boolean killConnections) in C:\Projects\smtpserver\Rnwood.SmtpServer\SmtpServer.cs:line 190
   at Rnwood.SmtpServer.SmtpServer.Stop() in C:\Projects\smtpserver\Rnwood.SmtpServer\SmtpServer.cs:line 167
   at Rnwood.SmtpServer.SmtpServer.Dispose(Boolean disposing) in C:\Projects\smtpserver\Rnwood.SmtpServer\SmtpServer.cs:line 222
   at Rnwood.SmtpServer.SmtpServer.Dispose() in C:\Projects\smtpserver\Rnwood.SmtpServer\SmtpServer.cs:line 115
   at Octopus.IntegrationTests.Core.EmailSending.SmtpClientWrapperFixture.WhenSendingAnEmailToAServerWithNoTls_TheEmailShouldBeAccepted() in C:\Projects\OctopusDeploy\source\Octopus.IntegrationTests\Core\EmailSending\SmtpClientWrapperFixture.cs:line 28
--AggregateException
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at Rnwood.SmtpServer.SmtpServer.<Start>b__24_0() in C:\Projects\smtpserver\Rnwood.SmtpServer\SmtpServer.cs:line 159
   at System.Threading.Tasks.Task.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__277_0(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--SocketException
   at System.Net.Sockets.Socket.GetException(SocketError error, Boolean wrapExceptionsInIOExceptions)
   at System.Net.Sockets.Socket.CompleteAccept(Socket s, TaskSocketAsyncEventArgs`1 saea)
   at System.Net.Sockets.Socket.<>c.<AcceptAsync>b__281_0(Object s, SocketAsyncEventArgs e)
   at System.Net.Sockets.SocketAsyncEventArgs.OnCompleted(SocketAsyncEventArgs e)
   at System.Net.Sockets.SocketAsyncEventArgs.OnCompletedInternal()
   at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationAsyncFailure(SocketError socketError, Int32 bytesTransferred, SocketFlags flags)
   at System.Net.Sockets.SocketAsyncEventArgs.HandleCompletionPortCallbackError(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
   at System.Net.Sockets.SocketAsyncEventArgs.<>c.<.cctor>b__179_0(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
   at System.Threading.ThreadPoolBoundHandleOverlapped.CompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
   at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pNativeOverlapped)
--- End of stack trace from previous location ---
   at System.Net.Sockets.TcpListener.<AcceptTcpClientAsync>g__WaitAndWrap|29_0(Task`1 task)
   at Rnwood.SmtpServer.SmtpServer.AcceptNextClient() in C:\Projects\smtpserver\Rnwood.SmtpServer\SmtpServer.cs:line 254
   at Rnwood.SmtpServer.SmtpServer.Core() in C:\Projects\smtpserver\Rnwood.SmtpServer\SmtpServer.cs:line 298
```

Hence the reason for this PR.

I tried to reproduce this exception in your tests but was unable, I am using net5 on my solution, so not sure if it has something to do with it or not.
The good news is that once I applied this patch locally I can no longer reproduce this exception.

Can you please consider this PR as an extra improvement to this awesome lib?