### PR TITLE
feat (CustomAuth): Provide ability to set a list of Auth mechanisms when configuring the server

### DIFF
--- a/Rnwood.SmtpServer.Tests/DefaultServerBehaviourTests.cs
+++ b/Rnwood.SmtpServer.Tests/DefaultServerBehaviourTests.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Rnwood.SmtpServer.Extensions.Auth;
+using Xunit;
+
+namespace Rnwood.SmtpServer.Tests
+{
+	public class DefaultServerBehaviourTests
+	{
+		private readonly Mock<IConnection> connectionMock;
+
+		public DefaultServerBehaviourTests()
+		{
+			connectionMock = new Mock<IConnection>();
+		}
+
+		[Fact]
+		public void CanSetAuthMechanismsViaSmtpServer()
+		{
+			var smtpServer = new DefaultServer(true);
+			smtpServer.Behaviour.EnabledAuthMechanisms.Clear();
+			smtpServer.Behaviour.EnabledAuthMechanisms.Add(new LoginMechanism());
+			smtpServer.Behaviour.EnabledAuthMechanisms.Count.Should().Be(1);
+
+		}
+
+		[Theory]
+		[ClassData(typeof(AuthMechanismData))]
+		public async Task EnsureDefaultBehaviourIsAllAUthMechanismsAreEnabled(IAuthMechanism authMechanism)
+		{
+			var defaultServerBehaviour = new DefaultServerBehaviour(true);
+			defaultServerBehaviour.EnabledAuthMechanisms.Should().NotBeNull();
+			var enabled = await defaultServerBehaviour.IsAuthMechanismEnabled(connectionMock.Object, authMechanism).ConfigureAwait(false);
+			enabled.Should().BeTrue();
+		}
+
+		[Theory]
+		[ClassData(typeof(AuthMechanismData))]
+		public async Task WhenASupportedAuthMechanismIdentifierIsConfiguredThenVerifyOnlyTheyAreEnabled(IAuthMechanism authMechanism)
+		{
+			var defaultServerBehaviour = new DefaultServerBehaviour(true);
+			var enabledMechanism = new PlainMechanism();
+			defaultServerBehaviour.EnabledAuthMechanisms.Clear();
+			defaultServerBehaviour.EnabledAuthMechanisms.Add(enabledMechanism);
+
+			var enabled = await defaultServerBehaviour.IsAuthMechanismEnabled(connectionMock.Object, authMechanism).ConfigureAwait(false);
+			if (authMechanism.Identifier == enabledMechanism.Identifier)
+			{
+				enabled.Should().BeTrue();
+			}
+			else
+			{
+				enabled.Should().BeFalse();
+			}
+		}
+	}
+
+	public class AuthMechanismData : IEnumerable<object[]>
+	{
+		public IEnumerator<object[]> GetEnumerator()
+		{
+			yield return new object[] { new CramMd5Mechanism() };
+			yield return new object[] { new AnonymousMechanism() };
+			yield return new object[] { new LoginMechanism() };
+			yield return new object[] { new PlainMechanism() };
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+}

--- a/Rnwood.SmtpServer.Tests/Rnwood.SmtpServer.Tests.csproj
+++ b/Rnwood.SmtpServer.Tests/Rnwood.SmtpServer.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>3.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
     <AssemblyName>Rnwood.SmtpServer.Tests</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>Rnwood.SmtpServer.Tests</PackageId>
@@ -19,24 +19,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="MailKit" Version="2.5.2" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Rnwood.SmtpServer.Tests/Rnwood.SmtpServer.Tests.csproj
+++ b/Rnwood.SmtpServer.Tests/Rnwood.SmtpServer.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>3.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Rnwood.SmtpServer.Tests</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>Rnwood.SmtpServer.Tests</PackageId>
@@ -25,7 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.1" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Rnwood.SmtpServer.Tests/Rnwood.SmtpServer.Tests.csproj
+++ b/Rnwood.SmtpServer.Tests/Rnwood.SmtpServer.Tests.csproj
@@ -19,15 +19,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NETStandard.Library" Version="2.0.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Moq" Version="4.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MailKit" Version="2.5.2" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Rnwood.SmtpServer.sln.DotSettings
+++ b/Rnwood.SmtpServer.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=STARTTLS/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Rnwood.SmtpServer.sln.DotSettings
+++ b/Rnwood.SmtpServer.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rnwood/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=STARTTLS/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Rnwood.SmtpServer/Connection.cs
+++ b/Rnwood.SmtpServer/Connection.cs
@@ -150,6 +150,11 @@ namespace Rnwood.SmtpServer
 			return result;
 		}
 
+		/// <summary>
+		/// Start the Tls stream.
+		/// </summary>
+		/// <param name="s">stream.</param>
+		/// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
 		internal async Task<Stream> StartImplicitTls(Stream s)
 		{
 			SslStream sslStream = new SslStream(s);
@@ -166,7 +171,7 @@ namespace Rnwood.SmtpServer
 				sslProtos = SslProtocols.None;
 			}
 
-			System.Security.Cryptography.X509Certificates.X509Certificate cert = 
+			System.Security.Cryptography.X509Certificates.X509Certificate cert =
 				await this.Server.Behaviour.GetSSLCertificate(this).ConfigureAwait(false);
 
 			await sslStream.AuthenticateAsServerAsync(cert, false, sslProtos, false).ConfigureAwait(false);
@@ -185,7 +190,6 @@ namespace Rnwood.SmtpServer
 
 				if (await this.Server.Behaviour.IsSSLEnabled(this).ConfigureAwait(false))
 				{
-
 					await this.ConnectionChannel.ApplyStreamFilter(this.StartImplicitTls).ConfigureAwait(false);
 
 					this.Session.SecureConnection = true;

--- a/Rnwood.SmtpServer/DefaultServer.cs
+++ b/Rnwood.SmtpServer/DefaultServer.cs
@@ -5,10 +5,8 @@
 
 namespace Rnwood.SmtpServer
 {
-	using System;
 	using System.Net;
 	using System.Security.Cryptography.X509Certificates;
-	using System.Threading.Tasks;
 
 	/// <summary>
 	/// A default subclass of <see cref="SmtpServer"/> which provides a default behaviour which is suitable for many simple
@@ -59,9 +57,9 @@ namespace Rnwood.SmtpServer
 		///
 		/// <param name="allowRemoteConnections">if set to <c>true</c> remote connections are allowed.</param>
 		/// <param name="portNumber">The port number.</param>
-		/// <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
-		public DefaultServer(bool allowRemoteConnections, int portNumber, X509Certificate implcitTlsCertificate)
-			: this(allowRemoteConnections, Dns.GetHostName(), portNumber, implcitTlsCertificate, null)
+		/// <param name="implicitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
+		public DefaultServer(bool allowRemoteConnections, int portNumber, X509Certificate implicitTlsCertificate)
+			: this(allowRemoteConnections, Dns.GetHostName(), portNumber, implicitTlsCertificate, null)
 		{
 		}
 
@@ -74,10 +72,10 @@ namespace Rnwood.SmtpServer
 		/// <param name="allowRemoteConnections">if set to <c>true</c> remote connections are allowed.</param>
 		/// <param name="domainName">The domain name the server will send in greeting</param>
 		/// <param name="portNumber">The port number.</param>
-		/// <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
+		/// <param name="implicitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
 		/// <param name="startTlsCertificate">The TLS certificate to use for STARTTLS.</param>
-		public DefaultServer(bool allowRemoteConnections, string domainName, int portNumber, X509Certificate implcitTlsCertificate, X509Certificate startTlsCertificate)
-			: this(new DefaultServerBehaviour(allowRemoteConnections, domainName, portNumber, implcitTlsCertificate, startTlsCertificate))
+		public DefaultServer(bool allowRemoteConnections, string domainName, int portNumber, X509Certificate implicitTlsCertificate, X509Certificate startTlsCertificate)
+			: this(new DefaultServerBehaviour(allowRemoteConnections, domainName, portNumber, implicitTlsCertificate, startTlsCertificate))
 		{
 		}
 
@@ -107,7 +105,7 @@ namespace Rnwood.SmtpServer
 		}
 
 		/// <summary>
-		/// Occurs when a mesage has been fully received but not yet acknlowledged by the server.
+		/// Occurs when a message has been fully received but not yet acknowledged by the server.
 		/// </summary>
 		public event AsyncEventHandler<ConnectionEventArgs> MessageCompletedEventHandler
 		{
@@ -116,7 +114,7 @@ namespace Rnwood.SmtpServer
 		}
 
 		/// <summary>
-		/// Occurs when a message has been receieved and acknlowledged by the server.
+		/// Occurs when a message has been received and acknowledged by the server.
 		/// </summary>
 		public event AsyncEventHandler<MessageEventArgs> MessageReceivedEventHandler
 		{

--- a/Rnwood.SmtpServer/DefaultServer.cs
+++ b/Rnwood.SmtpServer/DefaultServer.cs
@@ -70,7 +70,7 @@ namespace Rnwood.SmtpServer
 		/// </summary>
 		///
 		/// <param name="allowRemoteConnections">if set to <c>true</c> remote connections are allowed.</param>
-		/// <param name="domainName">The domain name the server will send in greeting</param>
+		/// <param name="domainName">The domain name the server will send in greeting.</param>
 		/// <param name="portNumber">The port number.</param>
 		/// <param name="implicitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
 		/// <param name="startTlsCertificate">The TLS certificate to use for STARTTLS.</param>

--- a/Rnwood.SmtpServer/DefaultServerBehaviour.cs
+++ b/Rnwood.SmtpServer/DefaultServerBehaviour.cs
@@ -12,8 +12,8 @@ namespace Rnwood.SmtpServer
 	using System.Security.Cryptography.X509Certificates;
 	using System.Text;
 	using System.Threading.Tasks;
-	using Rnwood.SmtpServer.Extensions;
-	using Rnwood.SmtpServer.Extensions.Auth;
+	using Extensions;
+	using Extensions.Auth;
 
 	/// <summary>
 	/// Implements a default <see cref="IServerBehaviour"/> which is suitable for many basic uses.
@@ -96,6 +96,12 @@ namespace Rnwood.SmtpServer
 		}
 
 		/// <summary>
+		/// List of active Auth Mechanism Identifiers.
+		/// </summary>
+		public HashSet<IAuthMechanism> EnabledAuthMechanisms { get; set; } =
+			new HashSet<IAuthMechanism>(AuthMechanisms.All());
+
+		/// <summary>
 		/// Occurs when authentication credential provided by the client need to be validated.
 		/// </summary>
 		public event AsyncEventHandler<AuthenticationCredentialsValidationEventArgs> AuthenticationCredentialsValidationRequiredEventHandler;
@@ -143,7 +149,8 @@ namespace Rnwood.SmtpServer
 		/// <inheritdoc/>
 		public virtual Task<IEnumerable<IExtension>> GetExtensions(IConnectionChannel connectionChannel)
 		{
-			List<IExtension> extensions = new List<IExtension>(new IExtension[] { new EightBitMimeExtension(), new SizeExtension(), new SmtpUtfEightExtension() });
+			List<IExtension> extensions = new List<IExtension>(new IExtension[]
+				{ new EightBitMimeExtension(), new SizeExtension(), new SmtpUtfEightExtension() });
 
 			if (this.startTlsCertificate != null)
 			{
@@ -185,7 +192,8 @@ namespace Rnwood.SmtpServer
 		/// <inheritdoc/>
 		public virtual Task<bool> IsAuthMechanismEnabled(IConnection connection, IAuthMechanism authMechanism)
 		{
-			return Task.FromResult(true);
+			return Task.FromResult(
+				this.EnabledAuthMechanisms.Any(x => x.Equals(authMechanism)));
 		}
 
 		/// <inheritdoc/>

--- a/Rnwood.SmtpServer/DefaultServerBehaviour.cs
+++ b/Rnwood.SmtpServer/DefaultServerBehaviour.cs
@@ -12,8 +12,8 @@ namespace Rnwood.SmtpServer
 	using System.Security.Cryptography.X509Certificates;
 	using System.Text;
 	using System.Threading.Tasks;
-	using Extensions;
-	using Extensions.Auth;
+	using Rnwood.SmtpServer.Extensions;
+	using Rnwood.SmtpServer.Extensions.Auth;
 
 	/// <summary>
 	/// Implements a default <see cref="IServerBehaviour"/> which is suitable for many basic uses.
@@ -50,9 +50,9 @@ namespace Rnwood.SmtpServer
 		/// </summary>
 		/// <param name="allowRemoteConnections">if set to <c>true</c> remote connections to the server are allowed.</param>
 		/// <param name="portNumber">The port number.</param>
-		/// <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
-		public DefaultServerBehaviour(bool allowRemoteConnections, int portNumber, X509Certificate implcitTlsCertificate)
-			: this(allowRemoteConnections, portNumber, implcitTlsCertificate, null)
+		/// <param name="implicitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
+		public DefaultServerBehaviour(bool allowRemoteConnections, int portNumber, X509Certificate implicitTlsCertificate)
+			: this(allowRemoteConnections, portNumber, implicitTlsCertificate, null)
 		{
 		}
 
@@ -61,10 +61,14 @@ namespace Rnwood.SmtpServer
 		/// </summary>
 		/// <param name="allowRemoteConnections">if set to <c>true</c> remote connections to the server are allowed.</param>
 		/// <param name="portNumber">The port number.</param>
-		/// <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
-		/// <param name="startTlsCertificate">The TLS certificate to use for STARTTLS</param>
-		public DefaultServerBehaviour(bool allowRemoteConnections, int portNumber, X509Certificate implcitTlsCertificate, X509Certificate startTlsCertificate)
-			: this(allowRemoteConnections, Dns.GetHostName(), portNumber, implcitTlsCertificate, startTlsCertificate)
+		/// <param name="implicitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
+		/// <param name="startTlsCertificate">The TLS certificate to use for STARTTLS.</param>
+		public DefaultServerBehaviour(
+			bool allowRemoteConnections,
+			int portNumber,
+			X509Certificate implicitTlsCertificate,
+			X509Certificate startTlsCertificate)
+			: this(allowRemoteConnections, Dns.GetHostName(), portNumber, implicitTlsCertificate, startTlsCertificate)
 		{
 		}
 
@@ -72,11 +76,16 @@ namespace Rnwood.SmtpServer
 		/// Initializes a new instance of the <see cref="DefaultServerBehaviour"/> class.
 		/// </summary>
 		/// <param name="allowRemoteConnections">if set to <c>true</c> remote connections to the server are allowed.</param>
-		/// <param name="domainName">The domain name the server will send in greeting</param>
+		/// <param name="domainName">The domain name the server will send in greeting.</param>
 		/// <param name="portNumber">The port number.</param>
 		/// <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
-		/// <param name="startTlsCertificate">The TLS certificate to use for STARTTLS</param>
-		public DefaultServerBehaviour(bool allowRemoteConnections, string domainName, int portNumber, X509Certificate implcitTlsCertificate, X509Certificate startTlsCertificate)
+		/// <param name="startTlsCertificate">The TLS certificate to use for STARTTLS.</param>
+		public DefaultServerBehaviour(
+			bool allowRemoteConnections,
+			string domainName,
+			int portNumber,
+			X509Certificate implcitTlsCertificate,
+			X509Certificate startTlsCertificate)
 		{
 			this.DomainName = domainName;
 			this.PortNumber = portNumber;
@@ -94,12 +103,6 @@ namespace Rnwood.SmtpServer
 			: this(allowRemoteConnections, 587, implcitTlsCertificate, null)
 		{
 		}
-
-		/// <summary>
-		/// List of active Auth Mechanism Identifiers.
-		/// </summary>
-		public HashSet<IAuthMechanism> EnabledAuthMechanisms { get; set; } =
-			new HashSet<IAuthMechanism>(AuthMechanisms.All());
 
 		/// <summary>
 		/// Occurs when authentication credential provided by the client need to be validated.
@@ -131,6 +134,12 @@ namespace Rnwood.SmtpServer
 		/// </summary>
 		public event AsyncEventHandler<SessionEventArgs> SessionStartedEventHandler;
 
+		/// <summary>
+		/// Gets or sets a List of active Auth Mechanism Identifiers.
+		/// </summary>
+		public HashSet<IAuthMechanism> EnabledAuthMechanisms { get; set; } =
+			new HashSet<IAuthMechanism>(AuthMechanisms.All());
+
 		/// <inheritdoc/>
 		public virtual string DomainName { get; private set; }
 
@@ -150,7 +159,9 @@ namespace Rnwood.SmtpServer
 		public virtual Task<IEnumerable<IExtension>> GetExtensions(IConnectionChannel connectionChannel)
 		{
 			List<IExtension> extensions = new List<IExtension>(new IExtension[]
-				{ new EightBitMimeExtension(), new SizeExtension(), new SmtpUtfEightExtension() });
+			{
+				new EightBitMimeExtension(), new SizeExtension(), new SmtpUtfEightExtension(),
+			});
 
 			if (this.startTlsCertificate != null)
 			{

--- a/Rnwood.SmtpServer/Extensions/Auth/AnonymousMechanism.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/AnonymousMechanism.cs
@@ -26,12 +26,13 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 		public override bool Equals(object obj)
 		{
 			return obj is AnonymousMechanism mechanism &&
-			       this.Identifier == mechanism.Identifier;
+				   this.Identifier == mechanism.Identifier;
 		}
 
+		/// <inheritdoc />
 		public override int GetHashCode()
 		{
-			return base.GetHashCode();
+			return this.Identifier.GetHashCode();
 		}
 	}
 }

--- a/Rnwood.SmtpServer/Extensions/Auth/AnonymousMechanism.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/AnonymousMechanism.cs
@@ -21,5 +21,17 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 		{
 			return new AnonymousMechanismProcessor(connection);
 		}
+
+		/// <inheritdoc/>
+		public override bool Equals(object obj)
+		{
+			return obj is AnonymousMechanism mechanism &&
+			       this.Identifier == mechanism.Identifier;
+		}
+
+		public override int GetHashCode()
+		{
+			return base.GetHashCode();
+		}
 	}
 }

--- a/Rnwood.SmtpServer/Extensions/Auth/AuthExtensionProcessor.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/AuthExtensionProcessor.cs
@@ -29,10 +29,11 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 		{
 			this.connection = connection;
 			this.MechanismMap = new AuthMechanismMap();
-			this.MechanismMap.Add(new CramMd5Mechanism());
-			this.MechanismMap.Add(new PlainMechanism());
-			this.MechanismMap.Add(new LoginMechanism());
-			this.MechanismMap.Add(new AnonymousMechanism());
+			foreach (var authMechanism in AuthMechanisms.All())
+			{
+				this.MechanismMap.Add(authMechanism);
+			}
+
 			connection.VerbMap.SetVerbProcessor("AUTH", new AuthVerb(this));
 		}
 

--- a/Rnwood.SmtpServer/Extensions/Auth/AuthExtensionProcessor.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/AuthExtensionProcessor.cs
@@ -37,7 +37,7 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 		}
 
 		/// <summary>
-		/// Gets the mechanism map which manages the list of available auth mechasims.
+		/// Gets the mechanism map which manages the list of available auth mechanisms.
 		/// </summary>
 		/// <value>
 		/// The mechanism map.
@@ -48,7 +48,7 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 		public async Task<string[]> GetEHLOKeywords()
 		{
 			IAuthMechanism[] mechanisms = (await this.GetEnabledAuthMechanisms().ConfigureAwait(false)).ToArray();
-			
+
 			if (mechanisms.Any())
 			{
 				string mids = string.Join(" ", mechanisms.Select(m => m.Identifier));

--- a/Rnwood.SmtpServer/Extensions/Auth/AuthMechanisms.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/AuthMechanisms.cs
@@ -1,15 +1,21 @@
-﻿using System.Collections.Generic;
+﻿// <copyright file="AuthMechanisms.cs" company="Rnwood.SmtpServer project contributors">
+// Copyright (c) Rnwood.SmtpServer project contributors. All rights reserved.
+// Licensed under the BSD license. See LICENSE.md file in the project root for full license information.
+// </copyright>
 
 namespace Rnwood.SmtpServer.Extensions.Auth
 {
+	using System.Collections.Generic;
+
 	/// <summary>
-	/// Authentication Mechanisms
+	/// Authentication Mechanisms.
 	/// </summary>
-	public class AuthMechanisms
+	public static class AuthMechanisms
 	{
 		/// <summary>
 		/// Return enumerable of all valid Auth Mechanisms.
 		/// </summary>
+		/// <returns>Enumerable collection of AuthMechanisms.</returns>
 		public static IEnumerable<IAuthMechanism> All()
 		{
 			yield return new CramMd5Mechanism();

--- a/Rnwood.SmtpServer/Extensions/Auth/AuthMechanisms.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/AuthMechanisms.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace Rnwood.SmtpServer.Extensions.Auth
+{
+	/// <summary>
+	/// Authentication Mechanisms
+	/// </summary>
+	public class AuthMechanisms
+	{
+		/// <summary>
+		/// Return enumerable of all valid Auth Mechanisms.
+		/// </summary>
+		public static IEnumerable<IAuthMechanism> All()
+		{
+			yield return new CramMd5Mechanism();
+			yield return new PlainMechanism();
+			yield return new LoginMechanism();
+			yield return new AnonymousMechanism();
+		}
+	}
+}

--- a/Rnwood.SmtpServer/Extensions/Auth/CramMd5Mechanism.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/CramMd5Mechanism.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Rnwood.SmtpServer project contributors. All rights reserved.
 // Licensed under the BSD license. See LICENSE.md file in the project root for full license information.
 // </copyright>
-
 namespace Rnwood.SmtpServer.Extensions.Auth
 {
 	/// <summary>
@@ -29,9 +28,10 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 				   this.Identifier == mechanism.Identifier;
 		}
 
+		/// <inheritdoc/>
 		public override int GetHashCode()
 		{
-			return base.GetHashCode();
+			return this.Identifier.GetHashCode();
 		}
 	}
 }

--- a/Rnwood.SmtpServer/Extensions/Auth/CramMd5Mechanism.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/CramMd5Mechanism.cs
@@ -21,5 +21,17 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 		{
 			return new CramMd5MechanismProcessor(connection, new RandomIntegerGenerator(), new CurrentDateTimeProvider());
 		}
+
+		/// <inheritdoc/>
+		public override bool Equals(object obj)
+		{
+			return obj is CramMd5Mechanism mechanism &&
+				   this.Identifier == mechanism.Identifier;
+		}
+
+		public override int GetHashCode()
+		{
+			return base.GetHashCode();
+		}
 	}
 }

--- a/Rnwood.SmtpServer/Extensions/Auth/LoginMechanism.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/LoginMechanism.cs
@@ -29,9 +29,10 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 				   this.Identifier == mechanism.Identifier;
 		}
 
+		/// <inheritdoc/>
 		public override int GetHashCode()
 		{
-			return base.GetHashCode();
+			return this.Identifier.GetHashCode();
 		}
 	}
 }

--- a/Rnwood.SmtpServer/Extensions/Auth/LoginMechanism.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/LoginMechanism.cs
@@ -21,5 +21,17 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 		{
 			return new LoginMechanismProcessor(connection);
 		}
+
+		/// <inheritdoc/>
+		public override bool Equals(object obj)
+		{
+			return obj is LoginMechanism mechanism &&
+				   this.Identifier == mechanism.Identifier;
+		}
+
+		public override int GetHashCode()
+		{
+			return base.GetHashCode();
+		}
 	}
 }

--- a/Rnwood.SmtpServer/Extensions/Auth/PlainMechanism.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/PlainMechanism.cs
@@ -6,7 +6,7 @@
 namespace Rnwood.SmtpServer.Extensions.Auth
 {
 	/// <summary>
-	/// Defines the <see cref="PlainMechanism" /> which implements the PLAIN auth mechnism.
+	/// Defines the <see cref="PlainMechanism" /> which implements the PLAIN auth mechanism.
 	/// </summary>
 	public class PlainMechanism : IAuthMechanism
 	{
@@ -29,9 +29,10 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 				   this.Identifier == mechanism.Identifier;
 		}
 
+		/// <inheritdoc/>
 		public override int GetHashCode()
 		{
-			return base.GetHashCode();
+			return this.Identifier.GetHashCode();
 		}
 	}
 }

--- a/Rnwood.SmtpServer/Extensions/Auth/PlainMechanism.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/PlainMechanism.cs
@@ -21,5 +21,17 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 		{
 			return new PlainMechanismProcessor(connection);
 		}
+
+		/// <inheritdoc/>
+		public override bool Equals(object obj)
+		{
+			return obj is PlainMechanism mechanism &&
+				   this.Identifier == mechanism.Identifier;
+		}
+
+		public override int GetHashCode()
+		{
+			return base.GetHashCode();
+		}
 	}
 }

--- a/Rnwood.SmtpServer/IServerBehaviour.cs
+++ b/Rnwood.SmtpServer/IServerBehaviour.cs
@@ -81,12 +81,17 @@ namespace Rnwood.SmtpServer
 		Task<X509Certificate> GetSSLCertificate(IConnection connection);
 
 		/// <summary>
-		/// Determines whether the speficied auth mechanism should be enabled for the specified connecton.
+		/// Determines whether the specified auth mechanism should be enabled for the specified connection.
 		/// </summary>
 		/// <param name="connection">The connection.</param>
 		/// <param name="authMechanism">The auth mechanism.</param>
 		/// <returns>A <see cref="Task{T}"/> representing the async operation.</returns>
 		Task<bool> IsAuthMechanismEnabled(IConnection connection, IAuthMechanism authMechanism);
+
+		/// <summary>
+		/// Set/Get the list of Supported Auth Mechanism Identifiers.
+		/// </summary>
+		HashSet<IAuthMechanism> EnabledAuthMechanisms { get; set; }
 
 		/// <summary>
 		/// Gets a value indicating whether session logging should be enabled for the given connection.

--- a/Rnwood.SmtpServer/IServerBehaviour.cs
+++ b/Rnwood.SmtpServer/IServerBehaviour.cs
@@ -46,6 +46,11 @@ namespace Rnwood.SmtpServer
 		Encoding FallbackEncoding { get; }
 
 		/// <summary>
+		/// Gets or sets the list of Supported Auth Mechanism Identifiers.
+		/// </summary>
+		HashSet<IAuthMechanism> EnabledAuthMechanisms { get; set; }
+
+		/// <summary>
 		/// Gets the extensions that should be enabled for the specified connection.
 		/// </summary>
 		/// <param name="connectionChannel">The connectionChannel<see cref="IConnectionChannel" />.</param>
@@ -87,11 +92,6 @@ namespace Rnwood.SmtpServer
 		/// <param name="authMechanism">The auth mechanism.</param>
 		/// <returns>A <see cref="Task{T}"/> representing the async operation.</returns>
 		Task<bool> IsAuthMechanismEnabled(IConnection connection, IAuthMechanism authMechanism);
-
-		/// <summary>
-		/// Set/Get the list of Supported Auth Mechanism Identifiers.
-		/// </summary>
-		HashSet<IAuthMechanism> EnabledAuthMechanisms { get; set; }
 
 		/// <summary>
 		/// Gets a value indicating whether session logging should be enabled for the given connection.

--- a/Rnwood.SmtpServer/Rnwood.SmtpServer.csproj
+++ b/Rnwood.SmtpServer/Rnwood.SmtpServer.csproj
@@ -24,10 +24,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/Rnwood.SmtpServer/Rnwood.SmtpServer.csproj
+++ b/Rnwood.SmtpServer/Rnwood.SmtpServer.csproj
@@ -24,10 +24,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/Rnwood.SmtpServer/Rnwood.SmtpServer.xml
+++ b/Rnwood.SmtpServer/Rnwood.SmtpServer.xml
@@ -362,6 +362,13 @@
             <param name="verbMap">The verb map.</param>
             <returns>An <see cref="T:System.Threading.Tasks.Task`1"/> representing the async operation.</returns>
         </member>
+        <member name="M:Rnwood.SmtpServer.Connection.StartImplicitTls(System.IO.Stream)">
+            <summary>
+            Start the Tls stream.
+            </summary>
+            <param name="s">stream.</param>
+            <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the result of the asynchronous operation.</returns>
+        </member>
         <member name="M:Rnwood.SmtpServer.Connection.ProcessAsync">
             <summary>
             Starts processing of this connection.
@@ -492,7 +499,7 @@
              </summary>
             
              <param name="allowRemoteConnections">if set to <c>true</c> remote connections are allowed.</param>
-             <param name="domainName">The domain name the server will send in greeting</param>
+             <param name="domainName">The domain name the server will send in greeting.</param>
              <param name="portNumber">The port number.</param>
              <param name="implicitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
              <param name="startTlsCertificate">The TLS certificate to use for STARTTLS.</param>
@@ -560,7 +567,7 @@
             </summary>
             <param name="allowRemoteConnections">if set to <c>true</c> remote connections to the server are allowed.</param>
             <param name="portNumber">The port number.</param>
-            <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
+            <param name="implicitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
         </member>
         <member name="M:Rnwood.SmtpServer.DefaultServerBehaviour.#ctor(System.Boolean,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate,System.Security.Cryptography.X509Certificates.X509Certificate)">
             <summary>
@@ -568,18 +575,18 @@
             </summary>
             <param name="allowRemoteConnections">if set to <c>true</c> remote connections to the server are allowed.</param>
             <param name="portNumber">The port number.</param>
-            <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
-            <param name="startTlsCertificate">The TLS certificate to use for STARTTLS</param>
+            <param name="implicitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
+            <param name="startTlsCertificate">The TLS certificate to use for STARTTLS.</param>
         </member>
         <member name="M:Rnwood.SmtpServer.DefaultServerBehaviour.#ctor(System.Boolean,System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate,System.Security.Cryptography.X509Certificates.X509Certificate)">
             <summary>
             Initializes a new instance of the <see cref="T:Rnwood.SmtpServer.DefaultServerBehaviour"/> class.
             </summary>
             <param name="allowRemoteConnections">if set to <c>true</c> remote connections to the server are allowed.</param>
-            <param name="domainName">The domain name the server will send in greeting</param>
+            <param name="domainName">The domain name the server will send in greeting.</param>
             <param name="portNumber">The port number.</param>
             <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
-            <param name="startTlsCertificate">The TLS certificate to use for STARTTLS</param>
+            <param name="startTlsCertificate">The TLS certificate to use for STARTTLS.</param>
         </member>
         <member name="M:Rnwood.SmtpServer.DefaultServerBehaviour.#ctor(System.Boolean,System.Security.Cryptography.X509Certificates.X509Certificate)">
             <summary>
@@ -587,11 +594,6 @@
             </summary>
             <param name="allowRemoteConnections">if set to <c>true</c> remote connections to the server are allowed.</param>
             <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
-        </member>
-        <member name="P:Rnwood.SmtpServer.DefaultServerBehaviour.EnabledAuthMechanisms">
-            <summary>
-            List of active Auth Mechanism Identifiers.
-            </summary>
         </member>
         <member name="E:Rnwood.SmtpServer.DefaultServerBehaviour.AuthenticationCredentialsValidationRequiredEventHandler">
             <summary>
@@ -621,6 +623,11 @@
         <member name="E:Rnwood.SmtpServer.DefaultServerBehaviour.SessionStartedEventHandler">
             <summary>
             Occurs when a new session is created, when a client connects to the server.
+            </summary>
+        </member>
+        <member name="P:Rnwood.SmtpServer.DefaultServerBehaviour.EnabledAuthMechanisms">
+            <summary>
+            Gets or sets a List of active Auth Mechanism Identifiers.
             </summary>
         </member>
         <member name="P:Rnwood.SmtpServer.DefaultServerBehaviour.DomainName">
@@ -715,6 +722,12 @@
         </member>
         <member name="M:Rnwood.SmtpServer.Extensions.Auth.AnonymousMechanism.CreateAuthMechanismProcessor(Rnwood.SmtpServer.IConnection)">
             <inheritdoc/>
+        </member>
+        <member name="M:Rnwood.SmtpServer.Extensions.Auth.AnonymousMechanism.Equals(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Rnwood.SmtpServer.Extensions.Auth.AnonymousMechanism.GetHashCode">
+            <inheritdoc />
         </member>
         <member name="T:Rnwood.SmtpServer.Extensions.Auth.AnonymousMechanismProcessor">
             <summary>
@@ -872,6 +885,17 @@
             Defines the Success
             </summary>
         </member>
+        <member name="T:Rnwood.SmtpServer.Extensions.Auth.AuthMechanisms">
+            <summary>
+            Authentication Mechanisms.
+            </summary>
+        </member>
+        <member name="M:Rnwood.SmtpServer.Extensions.Auth.AuthMechanisms.All">
+            <summary>
+            Return enumerable of all valid Auth Mechanisms.
+            </summary>
+            <returns>Enumerable collection of AuthMechanisms.</returns>
+        </member>
         <member name="T:Rnwood.SmtpServer.Extensions.Auth.AuthVerb">
             <summary>
             Defines the <see cref="T:Rnwood.SmtpServer.Extensions.Auth.AuthVerb" />.
@@ -968,6 +992,12 @@
             <inheritdoc/>
         </member>
         <member name="M:Rnwood.SmtpServer.Extensions.Auth.CramMd5Mechanism.CreateAuthMechanismProcessor(Rnwood.SmtpServer.IConnection)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Rnwood.SmtpServer.Extensions.Auth.CramMd5Mechanism.Equals(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Rnwood.SmtpServer.Extensions.Auth.CramMd5Mechanism.GetHashCode">
             <inheritdoc/>
         </member>
         <member name="T:Rnwood.SmtpServer.Extensions.Auth.CramMd5MechanismProcessor">
@@ -1099,6 +1129,12 @@
         <member name="M:Rnwood.SmtpServer.Extensions.Auth.LoginMechanism.CreateAuthMechanismProcessor(Rnwood.SmtpServer.IConnection)">
             <inheritdoc/>
         </member>
+        <member name="M:Rnwood.SmtpServer.Extensions.Auth.LoginMechanism.Equals(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Rnwood.SmtpServer.Extensions.Auth.LoginMechanism.GetHashCode">
+            <inheritdoc/>
+        </member>
         <member name="T:Rnwood.SmtpServer.Extensions.Auth.LoginMechanismProcessor">
             <summary>
             Defines the <see cref="T:Rnwood.SmtpServer.Extensions.Auth.LoginMechanismProcessor" />.
@@ -1157,7 +1193,7 @@
         </member>
         <member name="T:Rnwood.SmtpServer.Extensions.Auth.PlainMechanism">
             <summary>
-            Defines the <see cref="T:Rnwood.SmtpServer.Extensions.Auth.PlainMechanism" /> which implements the PLAIN auth mechnism.
+            Defines the <see cref="T:Rnwood.SmtpServer.Extensions.Auth.PlainMechanism" /> which implements the PLAIN auth mechanism.
             </summary>
         </member>
         <member name="P:Rnwood.SmtpServer.Extensions.Auth.PlainMechanism.Identifier">
@@ -1170,6 +1206,9 @@
             <inheritdoc/>
         </member>
         <member name="M:Rnwood.SmtpServer.Extensions.Auth.PlainMechanism.Equals(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Rnwood.SmtpServer.Extensions.Auth.PlainMechanism.GetHashCode">
             <inheritdoc/>
         </member>
         <member name="T:Rnwood.SmtpServer.Extensions.Auth.PlainMechanismProcessor">
@@ -1992,6 +2031,11 @@
             Gets an encoding which will be used if bytes received from the client cannot be decoded as ASCII/UTF-8.
             </summary>
         </member>
+        <member name="P:Rnwood.SmtpServer.IServerBehaviour.EnabledAuthMechanisms">
+            <summary>
+            Gets or sets the list of Supported Auth Mechanism Identifiers.
+            </summary>
+        </member>
         <member name="M:Rnwood.SmtpServer.IServerBehaviour.GetExtensions(Rnwood.SmtpServer.IConnectionChannel)">
             <summary>
             Gets the extensions that should be enabled for the specified connection.
@@ -2034,11 +2078,6 @@
             <param name="connection">The connection.</param>
             <param name="authMechanism">The auth mechanism.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the async operation.</returns>
-        </member>
-        <member name="P:Rnwood.SmtpServer.IServerBehaviour.EnabledAuthMechanisms">
-            <summary>
-            Set/Get the list of Supported Auth Mechanism Identifiers.
-            </summary>
         </member>
         <member name="M:Rnwood.SmtpServer.IServerBehaviour.IsSessionLoggingEnabled(Rnwood.SmtpServer.IConnection)">
             <summary>

--- a/Rnwood.SmtpServer/Rnwood.SmtpServer.xml
+++ b/Rnwood.SmtpServer/Rnwood.SmtpServer.xml
@@ -482,7 +482,7 @@
             
              <param name="allowRemoteConnections">if set to <c>true</c> remote connections are allowed.</param>
              <param name="portNumber">The port number.</param>
-             <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
+             <param name="implicitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
         </member>
         <member name="M:Rnwood.SmtpServer.DefaultServer.#ctor(System.Boolean,System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate,System.Security.Cryptography.X509Certificates.X509Certificate)">
              <summary>
@@ -494,7 +494,7 @@
              <param name="allowRemoteConnections">if set to <c>true</c> remote connections are allowed.</param>
              <param name="domainName">The domain name the server will send in greeting</param>
              <param name="portNumber">The port number.</param>
-             <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
+             <param name="implicitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
              <param name="startTlsCertificate">The TLS certificate to use for STARTTLS.</param>
         </member>
         <member name="M:Rnwood.SmtpServer.DefaultServer.#ctor(System.Boolean,Rnwood.SmtpServer.StandardSmtpPort)">
@@ -512,12 +512,12 @@
         </member>
         <member name="E:Rnwood.SmtpServer.DefaultServer.MessageCompletedEventHandler">
             <summary>
-            Occurs when a mesage has been fully received but not yet acknlowledged by the server.
+            Occurs when a message has been fully received but not yet acknowledged by the server.
             </summary>
         </member>
         <member name="E:Rnwood.SmtpServer.DefaultServer.MessageReceivedEventHandler">
             <summary>
-            Occurs when a message has been receieved and acknlowledged by the server.
+            Occurs when a message has been received and acknowledged by the server.
             </summary>
         </member>
         <member name="E:Rnwood.SmtpServer.DefaultServer.SessionCompletedEventHandler">
@@ -763,7 +763,7 @@
         </member>
         <member name="P:Rnwood.SmtpServer.Extensions.Auth.AuthExtensionProcessor.MechanismMap">
             <summary>
-            Gets the mechanism map which manages the list of available auth mechasims.
+            Gets the mechanism map which manages the list of available auth mechanisms.
             </summary>
             <value>
             The mechanism map.

--- a/Rnwood.SmtpServer/Rnwood.SmtpServer.xml
+++ b/Rnwood.SmtpServer/Rnwood.SmtpServer.xml
@@ -588,6 +588,11 @@
             <param name="allowRemoteConnections">if set to <c>true</c> remote connections to the server are allowed.</param>
             <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
         </member>
+        <member name="P:Rnwood.SmtpServer.DefaultServerBehaviour.EnabledAuthMechanisms">
+            <summary>
+            List of active Auth Mechanism Identifiers.
+            </summary>
+        </member>
         <member name="E:Rnwood.SmtpServer.DefaultServerBehaviour.AuthenticationCredentialsValidationRequiredEventHandler">
             <summary>
             Occurs when authentication credential provided by the client need to be validated.
@@ -1162,6 +1167,9 @@
             <inheritdoc/>
         </member>
         <member name="M:Rnwood.SmtpServer.Extensions.Auth.PlainMechanism.CreateAuthMechanismProcessor(Rnwood.SmtpServer.IConnection)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Rnwood.SmtpServer.Extensions.Auth.PlainMechanism.Equals(System.Object)">
             <inheritdoc/>
         </member>
         <member name="T:Rnwood.SmtpServer.Extensions.Auth.PlainMechanismProcessor">
@@ -2021,11 +2029,16 @@
         </member>
         <member name="M:Rnwood.SmtpServer.IServerBehaviour.IsAuthMechanismEnabled(Rnwood.SmtpServer.IConnection,Rnwood.SmtpServer.Extensions.Auth.IAuthMechanism)">
             <summary>
-            Determines whether the speficied auth mechanism should be enabled for the specified connecton.
+            Determines whether the specified auth mechanism should be enabled for the specified connection.
             </summary>
             <param name="connection">The connection.</param>
             <param name="authMechanism">The auth mechanism.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the async operation.</returns>
+        </member>
+        <member name="P:Rnwood.SmtpServer.IServerBehaviour.EnabledAuthMechanisms">
+            <summary>
+            Set/Get the list of Supported Auth Mechanism Identifiers.
+            </summary>
         </member>
         <member name="M:Rnwood.SmtpServer.IServerBehaviour.IsSessionLoggingEnabled(Rnwood.SmtpServer.IConnection)">
             <summary>

--- a/Rnwood.SmtpServer/TcpClientConnectionChannel.cs
+++ b/Rnwood.SmtpServer/TcpClientConnectionChannel.cs
@@ -207,7 +207,7 @@ namespace Rnwood.SmtpServer
 
 			this.reader = new SmtpStreamReader(this.stream, this.fallbackEncoding, true);
 
-			if(this.writer != null)
+			if (this.writer != null)
 			{
 				this.writer.Dispose();
 			}


### PR DESCRIPTION
Ability to set a list of active Auth Mechanisms when constructing the SmtpServer.  By default all existing mechanisms are active.

* Maintain a collection of active identifiers in the DefaultServerBehaviour, provide the opportunity of the downstream consumer to amend/clear list as desired.
* Fixed a few minor spellings
* Bumped packages relating to tests/mocks.
 * Replace deprecated Microsoft.CodeAnalysis.FxCopAnalyzers with Microsoft.CodeAnalysis.NetAnalyzers

Resolves #145 
and hopefully enables https://github.com/rnwood/smtp4dev/issues/852 to to progress.

🏁  One thing to review, I see IConnection is passed into the methods, but not really being used.
